### PR TITLE
Skip element if errors in metadata server

### DIFF
--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -48,6 +48,7 @@ KNOWN_CLOUD_NAMES = [
     "VMware",
     "Vultr",
     "ZStack",
+    "Outscale",
     "Other",
 ]
 

--- a/cloudinit/sources/helpers/ec2.py
+++ b/cloudinit/sources/helpers/ec2.py
@@ -190,6 +190,7 @@ def _get_instance_metadata(
     headers_cb=None,
     headers_redact=None,
     exception_cb=None,
+    retrieval_exception_ignore_cb=None,
 ):
     md_url = url_helper.combine_url(metadata_address, api_version, tree)
     caller = functools.partial(
@@ -203,7 +204,17 @@ def _get_instance_metadata(
     )
 
     def mcaller(url):
-        return caller(url).contents
+        try:
+            return caller(url).contents
+        except url_helper.UrlError as e:
+            if (
+                not retrieval_exception_ignore_cb
+                or not retrieval_exception_ignore_cb(e)
+            ):
+                raise
+            else:
+                LOG.warning("Skipped retrieval of the content of %s", base_url)
+                return "(skipped)"
 
     try:
         response = caller(md_url)
@@ -229,6 +240,7 @@ def get_instance_metadata(
     headers_cb=None,
     headers_redact=None,
     exception_cb=None,
+    retrieval_exception_ignore_cb=None,
 ):
     # Note, 'meta-data' explicitly has trailing /.
     # this is required for CloudStack (LP: #1356855)
@@ -243,6 +255,7 @@ def get_instance_metadata(
         headers_redact=headers_redact,
         headers_cb=headers_cb,
         exception_cb=exception_cb,
+        retrieval_exception_ignore_cb=retrieval_exception_ignore_cb,
     )
 
 

--- a/cloudinit/sources/helpers/ec2.py
+++ b/cloudinit/sources/helpers/ec2.py
@@ -213,7 +213,7 @@ def _get_instance_metadata(
             ):
                 raise
             else:
-                LOG.warning("Skipped retrieval of the content of %s", base_url)
+                LOG.warning("Skipped retrieval of the content of %s", url)
                 return "(skipped)"
 
     try:

--- a/doc/rtd/topics/availability.rst
+++ b/doc/rtd/topics/availability.rst
@@ -60,6 +60,7 @@ environments in the public cloud:
 - UpCloud
 - Vultr
 - Zadara Edge Cloud Platform
+- 3DS Outscale
 
 Additionally, cloud-init is supported on these private clouds:
 

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -805,13 +805,13 @@ class TestEc2(test_helpers.HttprettyTestCase):
         ]
         for attr_name in platform_attrs:
             platform_name = getattr(ec2.CloudNames, attr_name)
-            if platform_name != "aws":
+            if platform_name not in ["aws", "outscale"]:
                 ds._cloud_name = platform_name
                 ret = ds.get_data()
                 self.assertEqual("ec2", ds.platform_type)
                 self.assertFalse(ret)
                 message = (
-                    "Local Ec2 mode only supported on ('aws',),"
+                    "Local Ec2 mode only supported on ('aws', 'outscale'),"
                     " not {0}".format(platform_name)
                 )
                 self.assertIn(message, self.logs.getvalue())
@@ -1176,6 +1176,7 @@ class TesIdentifyPlatform(test_helpers.CiTestCase):
             "uuid": "81c7e555-6471-4833-9551-1ab366c4cfd2",
             "uuid_source": "dmi",
             "vendor": "tothecloud",
+            "product_name": "cloudproduct",
         }
         unspecial.update(**kwargs)
         return unspecial
@@ -1206,6 +1207,34 @@ class TesIdentifyPlatform(test_helpers.CiTestCase):
     def test_identify_e24cloud_negative(self, m_collect):
         """e24cloud identified if vendor is e24cloud"""
         m_collect.return_value = self.collmock(vendor="e24cloudyday")
+        self.assertEqual(ec2.CloudNames.UNKNOWN, ec2.identify_platform())
+
+    # Outscale
+    @mock.patch("cloudinit.sources.DataSourceEc2._collect_platform_data")
+    def test_identify_outscale(self, m_collect):
+        """Should return true if the dmi product data has expected value."""
+        m_collect.return_value = self.collmock(
+            vendor="3DS Outscale".lower(),
+            product_name="3DS Outscale VM".lower(),
+        )
+        self.assertEqual(ec2.CloudNames.OUTSCALE, ec2.identify_platform())
+
+    @mock.patch("cloudinit.sources.DataSourceEc2._collect_platform_data")
+    def test_false_on_wrong_sys_vendor(self, m_collect):
+        """Should return false on empty value returned."""
+        m_collect.return_value = self.collmock(
+            vendor="Not 3DS Outscale".lower(),
+            product_name="3DS Outscale VM".lower(),
+        )
+        self.assertEqual(ec2.CloudNames.UNKNOWN, ec2.identify_platform())
+
+    @mock.patch("cloudinit.sources.DataSourceEc2._collect_platform_data")
+    def test_false_on_wrong_product_name(self, m_collect):
+        """Should return false on an unrelated string."""
+        m_collect.return_value = self.collmock(
+            vendor="3DS Outscale".lower(),
+            product_name="Not 3DS Outscale VM".lower(),
+        )
         self.assertEqual(ec2.CloudNames.UNKNOWN, ec2.identify_platform())
 
 

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -808,6 +808,18 @@ class TestDsIdentify(DsIdentifyBase):
         """EC2: bobrightbox.com in product_serial is not brightbox'"""
         self._test_ds_not_found("Ec2-E24Cloud-negative")
 
+    def test_outscale_is_ec2(self):
+        """EC2: outscale identified by sys_vendor and product_name"""
+        self._test_ds_found("Ec2-Outscale")
+
+    def test_outscale_not_active_sysvendor(self):
+        """EC2: outscale in sys_vendor is not outscale'"""
+        self._test_ds_not_found("Ec2-Outscale-negative-sysvendor")
+
+    def test_outscale_not_active_productname(self):
+        """EC2: outscale in product_name is not outscale'"""
+        self._test_ds_not_found("Ec2-Outscale-negative-productname")
+
     def test_vmware_no_valid_transports(self):
         """VMware: no valid transports"""
         self._test_ds_not_found("VMware-NoValidTransports")
@@ -1809,6 +1821,27 @@ VALID_CFG = {
             },
             MOCK_VIRT_IS_VMWARE,
         ],
+    },
+    "Ec2-Outscale": {
+        "ds": "Ec2",
+        "files": {
+            P_PRODUCT_NAME: "3DS Outscale VM\n",
+            P_SYS_VENDOR: "3DS Outscale\n",
+        },
+    },
+    "Ec2-Outscale-negative-sysvendor": {
+        "ds": "Ec2",
+        "files": {
+            P_PRODUCT_NAME: "3DS Outscale VM\n",
+            P_SYS_VENDOR: "Not 3DS Outscale\n",
+        },
+    },
+    "Ec2-Outscale-negative-productname": {
+        "ds": "Ec2",
+        "files": {
+            P_PRODUCT_NAME: "Not 3DS Outscale VM\n",
+            P_SYS_VENDOR: "3DS Outscale\n",
+        },
     },
 }
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -80,6 +80,7 @@ olivierlemasle
 omBratteng
 onitake
 Oursin
+outscale-mdr
 qubidt
 RedKrieg
 renanrodrigo

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1135,6 +1135,13 @@ ec2_identify_platform() {
         e24cloud) _RET="E24cloud"; return 0;;
     esac
 
+
+    local product_name="${DI_DMI_PRODUCT_NAME}"
+    if [ "${product_name}" = "3DS Outscale VM" ]  && \
+       [ "${vendor}" = "3DS Outscale" ]; then
+        _RET="Outscale"; return 0
+    fi
+
     # AWS http://docs.aws.amazon.com/AWSEC2/
     #     latest/UserGuide/identify_ec2_instances.html
     local uuid="" hvuuid="${PATH_SYS_HYPERVISOR}/uuid"


### PR DESCRIPTION
Right now if some elements are not available in the metadata, the retrieval fails and it crashs. We propose to add the ability to skip some element if necessary.

Use-case: our tags can have invalid URI characters like '/' in the middle. Wewould like to be able to continue if some elements are not available with something like:

```python
def _skip_tags(exception):
    if isinstance(exception, uhelp.UrlError) and exception.code == 404:
        if "meta-data/tags/" in exception.url:
            print(exception.url)
            return True
    return False
data = ec2.get_instance_metadata(
                headers_cb=None,
                skip_cb=_skip_tags
            )
```